### PR TITLE
[1.0.0] Fix issues when compiling to YYC output

### DIFF
--- a/SonicTT/objects/objScreen/Draw_0.gml
+++ b/SonicTT/objects/objScreen/Draw_0.gml
@@ -1,12 +1,10 @@
-/// @description  Screenshot and scanlines
-if screenshot > -1 && !instance_exists(objSSHud)
+/// @description Snapshot
+if (sprite_exists(screenshot) and not instance_exists(objSSHud))
 {
-    draw_enable_alphablend(false);
-    draw_background_stretched_ext(screenshot, __view_get( e__VW.XView, view_current ), __view_get( e__VW.YView, view_current ), width, height, c_white, 1);
-    draw_enable_alphablend(true);
+	var camera = view_get_camera(view_current);
+	var view_x = camera_get_view_x(camera);
+	var view_y = camera_get_view_y(camera);
+	gpu_set_blendenable(false);
+	draw_sprite_stretched_ext(screenshot, 0, view_x, view_y, width, height, c_white, 1);
+	gpu_set_blendenable(true);
 }
-else if scanlines
-{
-    draw_background_stretched(backScanlines, 0, 0, room_width, 480);
-}
-

--- a/SonicTT/objects/objTimePost/Alarm_0.gml
+++ b/SonicTT/objects/objTimePost/Alarm_0.gml
@@ -1,0 +1,1 @@
+/// @description Do nothing

--- a/SonicTT/objects/objTimePost/Create_0.gml
+++ b/SonicTT/objects/objTimePost/Create_0.gml
@@ -1,11 +1,15 @@
-action_inherited();
+/// @description Initialize
+event_inherited();
 image_speed = 0;
 reaction_script = player_reaction_time_post;
-tag = 0;
 player_id = noone;
-if objProgram.in_past == true {
+tag = 0;
+radius = 10;
+default_cancel_speed = 8;
+default_reset_time = 24;
+time_travel_reset_time = 40;
 
-    sprite_index = sprFuturePost;
-
+with (objProgram)
+{
+	if (in_past) other.sprite_index = sprFuturePost;
 }
-

--- a/SonicTT/objects/objTimePost/Step_0.gml
+++ b/SonicTT/objects/objTimePost/Step_0.gml
@@ -54,11 +54,17 @@ with (player_id)
 		other.player_id = noone;
 
 		// confirm time travel
+		var tag = other.tag;
+		var time = 0;
+		with (objLevel)
+		{
+			time = timer;
+		}
 		with (objProgram)
 		{
-			spawn_tag = other.tag;
-			spawn_time = objLevel.timer;
-			time_traveling = facing;
+			spawn_tag = tag;
+			spawn_time = time;
+			time_traveling = other.facing;
 			audio_play_sound((in_past) ? sndChantFuture : sndChantPast, 1, false);
 		}
 

--- a/SonicTT/objects/objTimePost/Step_0.gml
+++ b/SonicTT/objects/objTimePost/Step_0.gml
@@ -1,80 +1,70 @@
-/// @description  Control player
-
-// custom player state
-with player_id
+/// @description Control
+var pole_dir;
+with (player_id)
 {
-    // rotate around post
-    x = other.x+sine[angle_wrap(timeline_position*30)]*10*facing;
-    if timeline_position>3 and timeline_position<10 depth = other.depth+1; else
-    depth = 0;
+	// rotate around post
+	pole_dir = angle_wrap(timeline_position * 30);
+	x = other.x + dsin(pole_dir) * other.radius * facing;
 
-    // activate on end of animation
-    if timeline_position>=12
-    {
-        // reset time post
-        other.alarm[0] = 40;
-        other.player_id = noone;
+	// jumping
+	if (input_check_pressed(cACTION))
+	{
+		// reset time post
+		other.alarm[0] = other.default_reset_time;
+		other.player_id = noone;
 
-        // confirm time travel
-        objProgram.spawn_tag = other.tag;
-        objProgram.spawn_time = objLevel.timer;
-        objProgram.time_traveling = facing;
+		// detach
+		player_is_jumping();
 
-        // camera
-        camera.alarm[0] = 128;
+		x = other.x;
+		xspeed = other.default_cancel_speed * facing;
+		camera.alarm[0] = -1;
 
-        // audio
-        if objProgram.in_past audio_play_sound(sndChantFuture, 1, false); else
-        audio_play_sound(sndChantPast, 1, false);
+		animation_new = "brake";
+		timeline_speed = 1;	
+		depth = 0;
+		exit;
+	}
 
-        // time travel
-        return player_is_exiting();
-    }
+	// cancelling
+	if (input_axis_x() == -facing)
+	{
+		// reset time post
+		other.alarm[0] = other.default_reset_time;
+		other.player_id = noone;
 
-    // cancelling
-    if (input_axis_x() == -facing)
-    {
-        // reset time post
-        other.alarm[0] = 24;
-        other.player_id = noone;
+		// detach
+		player_is_running();
 
-        // animate
-        animation_new = "brake";
-        timeline_speed = 1;
+		x = other.x;
+		xspeed = other.default_cancel_speed * facing;
+		camera.alarm[0] = -1;
 
-        // movement and collision
-        x = other.x;
-        xspeed = 8*facing;
+		animation_new = "brake";
+		timeline_speed = 1;	
+		depth = 0;
+		exit;
+	}
 
-        // camera
-        camera.alarm[0] = -1;
+	// activate on end of animation
+	if (timeline_position >= 12)
+	{
+		// reset time post
+		other.alarm[0] = other.time_travel_reset_time;
+		other.player_id = noone;
 
-        // other
-        depth = 0;
+		// confirm time travel
+		with (objProgram)
+		{
+			spawn_tag = other.tag;
+			spawn_time = objLevel.timer;
+			time_traveling = facing;
+			audio_play_sound((in_past) ? sndChantFuture : sndChantPast, 1, false);
+		}
 
-        // running
-        return player_is_running();
-    }
-
-    // jumping
-    if input_check_pressed(cACTION)
-    { 
-        // reset time post
-        other.alarm[0] = 24;
-        other.player_id = noone;
-
-        // movement and collision
-        x = other.x;
-        xspeed = 8*facing;
-
-        // camera
-        camera.alarm[0] = -1;
-
-        // other
-        depth = 0;
-
-        // running
-        return player_is_jumping();
-    }
+		// time travel
+		camera.alarm[0] = 128;
+		player_is_exiting();
+		exit;
+	}
 }
-

--- a/SonicTT/objects/objTimePost/Step_2.gml
+++ b/SonicTT/objects/objTimePost/Step_2.gml
@@ -1,0 +1,7 @@
+/// @description Animate
+event_inherited();
+with (player_id)
+{
+	// rotate around post
+	depth = (timeline_position > 3 and timeline_position < 10) ? other.depth + 1 : 0;
+}

--- a/SonicTT/objects/objTimePost/objTimePost.yy
+++ b/SonicTT/objects/objTimePost/objTimePost.yy
@@ -33,6 +33,16 @@
             "enumb": 0,
             "eventtype": 3,
             "m_owner": "c4ccfbda-3a1b-4389-9acc-397ac7b6f6cb"
+        },
+        {
+            "id": "e5e6e5b7-5269-47b2-9671-7c2f61b65437",
+            "modelName": "GMEvent",
+            "mvc": "1.0",
+            "IsDnD": false,
+            "collisionObjectId": "00000000-0000-0000-0000-000000000000",
+            "enumb": 2,
+            "eventtype": 3,
+            "m_owner": "c4ccfbda-3a1b-4389-9acc-397ac7b6f6cb"
         }
     ],
     "maskSpriteId": "00000000-0000-0000-0000-000000000000",


### PR DESCRIPTION
These commits fix issues discovered while compiling to and testing the game in YoYo Compiler (YYC) output:

- A leftover reference to a cut scan lines filter was preventing compilation. This cut feature may be revisited in the future, (#12) but has been completely removed for now.
- Terrain surface normal calculation was not consistent with VM output; this has been corrected. Closes #13
- Fixed the player character getting stuck and not exiting the screen when using Time Posts. Closes #14