### PR TITLE
[1.0.0] Fix shaders and Attraction Attack flippers

### DIFF
--- a/SonicTT/objects/objAAFlipper/Create_0.gml
+++ b/SonicTT/objects/objAAFlipper/Create_0.gml
@@ -1,7 +1,9 @@
-action_inherited();
-/// Initialize
+/// @description Initialize
+event_inherited();
 image_speed = 0;
 timeline_index = animFlipper;
 reaction_script = player_reaction_AA_flipper;
 player_id = noone;
-
+roll_speed = 0.5 * image_xscale;
+flip_xspeed = 0.15;
+flip_yspeed = -14;

--- a/SonicTT/objects/objAAFlipper/Step_0.gml
+++ b/SonicTT/objects/objAAFlipper/Step_0.gml
@@ -1,46 +1,55 @@
-/// @description  Control player
-with player_id
+/// @description Control
+with (player_id)
 {
+	// roll off
+	xspeed = other.roll_speed;
+	if (not player_movement_ground())
+	{
+		other.player_id = noone;
+		break;
+	}
 
-    // ground motion
-    xspeed = 0.5*other.image_xscale;
-    
-    // update position
-    if not player_movement_ground() {other.player_id = noone; return false;}
-    
-    // falling
-    //if not landed {other.player_id = noone; return player_is_falling();}
-    if other.image_xscale == 1 {  
-        if bbox_left > other.bbox_right { other.player_id = noone; return player_is_falling(); }
-    }
-    else {
-        if bbox_right < other.bbox_left { other.player_id = noone; return player_is_falling(); }
-    }
-    // release control if not on flipper
-    if (terrain_id!=other.id) {other.player_id = noone; return player_is_rolling();}
+	// detach if not on flipper
+	if (terrain_id != other.id)
+	{
+		if (instance_exists(terrain_id))
+		{
+			player_is_rolling();
+		}
+		else
+		{
+			player_is_falling();
+		}
+		other.player_id = noone;
+		break;
+	}
 
-    // fling upward
-    if input_check_pressed(cACTION)
-    {
-        // states and flags
-        state = player_state_fall;
-        spinning = false;
-        rolling_jump = false;
-        jump_action = true;
+	// fall when out of bounds
+	var xscale = sign(other.image_xscale);
+	if ((xscale == -1 and x + offset_x < other.bbox_left) or
+		(xscale == 1 and x - offset_x > other.bbox_right))
+	{
+		player_is_falling();
+		other.player_id = noone;
+		break;
+	}
 
-        // movement and collision
-        xspeed = (x-other.x)*0.15;
-        yspeed = -14;
+	// fling
+	if (input_check_pressed(cACTION))
+	{
+		state = player_state_fall;
+		spinning = false;
+		rolling_jump = false;
+		jump_action = true;
+		xspeed = (x - other.x) * other.flip_xspeed;
+		yspeed = other.flip_yspeed;
+		player_in_air();
 
-        // set air state
-        player_in_air();
+		audio_play_sound(sndFlipper, 1, false);
 
-        // release control and animate
-        other.timeline_running = true;
-        other.timeline_position = 0;
-        other.player_id = noone;
-        
-        audio_play_sound(sndFlipper,1,false);
-    }
+		other.timeline_running = true;
+		other.timeline_position = 0;
+		other.player_id = noone;
+		break;
+	}
 }
-

--- a/SonicTT/objects/objTimeTravel/Create_0.gml
+++ b/SonicTT/objects/objTimeTravel/Create_0.gml
@@ -1,49 +1,49 @@
-action_inherited();
-mode = 1;
-facing = objProgram.time_traveling;
-/// Setup Shader
+/// @description Initialize
+event_inherited();
+image_speed = 0;
+image_xscale = 2;
+image_yscale = 2;
+
+with (objProgram)
+{
+	other.image_xscale *= time_traveling;
+}
+
 /*
 TIME TRAVEL EFFECT
-This effect is achieved by drawing an animation (in this case, a scaled sprite) to a surface.
-This results in a white on transparent image on the surface. When the surface is drawn with the TimeTravelShader applied,
-the white pixels will be replaced with a texture that makes it look like the SCD time travel effect.
+This effect is achieved by drawing an animation (in this case, a scaled sprite)
+to a surface. This results in a white on transparent image on the surface. When
+the surface is drawn with the TimeTravelShader applied, the white pixels will be
+replaced with a texture that makes it look like the SCD time travel effect.
 */
 
-// send some information to the shader; the shader has to be set for this to work
-// (I don't know if this can be screwed up by using other shaders; if so, this info might have to be sent in the draw event...)
-shader_set(TimeTravelShader);
-// send: the scaling of the sparkly SCD texture so it will repeat enough times to not be stretched
-shader_set_uniform_f(shader_get_uniform(TimeTravelShader, "scl"), 426 / background_get_width(tt_texture), 240 / background_get_height(tt_texture));
-// send: the texture index of the sparkly SCD texture
-texture_set_stage(shader_get_sampler_index(TimeTravelShader, "mask"), background_get_texture(tt_texture));
-// send: the texture index of the the gradient used to cycle the colours
-texture_set_stage(shader_get_sampler_index(TimeTravelShader, "grad"), background_get_texture(tt_gradient));
-shader_reset();
+shader = TimeTravelShader;
+param_scl = shader_get_uniform(shader, "scl");					
+param_mask = shader_get_sampler_index(shader, "mask");			
+param_grad = shader_get_sampler_index(shader, "grad");			
+param_shift = shader_get_uniform(shader, "shift");	
 
-// create a surface the size of the screen to draw the effect on
-tt_surface = surface_create(426, 240);
+screen_width = 426;
+screen_height = 240;
+half_height = screen_height * 0.5;
+surface = surface_create(screen_width, screen_height);
+xscale = screen_width / background_get_width(tt_texture);		// the scaling of the sparkly SCD texture so it will repeat enough times to not be stretched
+yscale = screen_height / background_get_height(tt_texture);
+tx_mask = background_get_texture(tt_texture);					// the texture index of the sparkly SCD texture
+tx_grad = background_get_texture(tt_gradient);					// the texture index of the the gradient used to cycle the colours
 
-// I've included two types of "zipper animation" - see step event
-type = false;
-// the image index of the animated sprite that will be drawn to the texture
-image_index = 0;
-image_speed = 0;
-
-// the amount to shift the gradient to cycle the colours; starts at 0
-// it's also used to slide the texture horizontally to give it some motion, but you could use a 2nd value
-// if the speeds need to be tweaked
+/*
+The amount to shift the gradient to cycle the colours. It's also used to slide
+the texture horizontally to give it some motion, but you could use a 2nd value
+if the speeds need to be tweaked
+*/
 shift = 0;
+cycle_speed = 0.01;
 
-// the parameter handle to be used to send the shift amount to the shader later in the draw event
-param_shift = shader_get_uniform(TimeTravelShader, "shift");
-
-image_xscale=2*facing;
-image_yscale=2;
-spr=sprTimeTravelEffect;
-
-if image_xscale == -2 {
-   xoffset=426;
-} else xoffset=0;
-
-/* */
-/*  */
+// transition properties
+state = "exiting";
+xoffset = (sign(image_xscale) == -1) ? screen_width : 0;
+frame_speed = 0.5;
+total_frames = sprite_get_number(sprite_index);
+sprite_xscale = abs(image_xscale);
+sprite_yscale = abs(image_yscale);

--- a/SonicTT/objects/objTimeTravel/Draw_0.gml
+++ b/SonicTT/objects/objTimeTravel/Draw_0.gml
@@ -1,14 +1,18 @@
+/// @description Shade
+if (view_current == 0)
+{
+	var camera = view_get_camera(0);
+	var xview = camera_get_view_x(camera);
+	var yview = camera_get_view_y(camera);
 
-// draw a dummy background for the effect to cover
-//draw_background_ext(zonebkg, 0, 0, 2, 2, 0, c_white, 1);
-// turn on the time travel effect shader
-shader_set(TimeTravelShader);
-// send the shift amount (for colour cycling) to the shader
-shader_set_uniform_f(param_shift, shift);
-// draw the surface with the zipper animation on it
-// (here it's scaled by 2 just to see it better)
-draw_surface_ext(tt_surface, __view_get( e__VW.XView, 0 )+xoffset, __view_get( e__VW.YView, 0 ), image_xscale, image_yscale, 0, c_white, 1);
-// turn off the shader
-shader_reset();
-
-
+	shader_set(shader);
+	shader_set_uniform_f(param_scl, xscale, yscale);
+	texture_set_stage(param_mask, tx_mask);
+	texture_set_stage(param_grad, tx_grad);
+	shader_set_uniform_f(param_shift, shift);
+	draw_surface_ext(
+		surface, xview + xoffset, yview, 
+		image_xscale, image_yscale, image_angle, image_blend, image_alpha
+	);
+	shader_reset();
+}

--- a/SonicTT/objects/objTimeTravel/Draw_72.gml
+++ b/SonicTT/objects/objTimeTravel/Draw_72.gml
@@ -1,0 +1,19 @@
+/// @description Draw surface
+if (view_current == 0)
+{
+	if (not surface_exists(surface))
+	{
+		surface = surface_create(screen_width, screen_height);
+	}
+	surface_set_target(surface);
+	draw_clear_alpha(0, 0)
+	draw_sprite_ext(
+		sprite_index, image_index, 0, 0, 
+		sprite_xscale, sprite_yscale, 0, c_white, 1
+	);
+	draw_sprite_ext(
+		sprite_index, image_index, 0, 
+		half_height, sprite_xscale, -sprite_yscale, 0, c_white, 1
+	);
+	surface_reset_target();
+}

--- a/SonicTT/objects/objTimeTravel/Step_0.gml
+++ b/SonicTT/objects/objTimeTravel/Step_0.gml
@@ -1,53 +1,31 @@
-
-/// Get transition mode
-switch mode
+/// @description Transition
+switch (state)
 {
-case 1: // wipe out
-    if (image_index > 32 )
-    {
-        if next_room>-1 room_goto(next_room);
-        mode = 0;
-        break;
-    }
-        image_index += .5;
-    break;
+case "exiting":
+	if (image_index > total_frames - 1)
+	{
+		image_index = total_frames - 1;
+		if (room_exists(next_room)) room_goto(next_room);
+		state = "transitioning";
+	}
+	break;
 
-case 0: // start level
-    objLevel.started = true;
-    objLevel.timer_enabled = true;
-    with objHud visible = true;
-    mode = -1;
-    //xoffset=426;
-    image_xscale = image_xscale*-1;
-    
-    if image_xscale == -2 {
-       xoffset=426;
-    } else xoffset=0;
-    break;
+case "transitioning":
+	with (objLevel)
+	{
+		started = true;
+		timer_enabled = true;
+	}
+	with (objHud)
+	{
+		visible = true;
+	}
+	image_xscale = -image_xscale;
+	xoffset = (sign(image_xscale) == -1) ? screen_width : 0;
+	state = "entering";
+	break;
 
-case -1: // wipe in
-    if (image_index <= 0) {instance_destroy(); break;}
-        image_index -= .5;
-    break;
+case "entering":
+	if (image_index <= 0) instance_destroy();
+	break;
 }
-
-
-if !surface_exists(tt_surface)
-    tt_surface = surface_create(426, 240);
-
-// set the drawing target to the surface
-surface_set_target(tt_surface);
-// clear the surface
-draw_clear_alpha(0, 0);
-// draw the sprite mirrored on the y axis to create the zipper shape
-draw_sprite_ext(spr, floor(image_index), 0, 0, 2, 2, 0, c_white, 1);
-draw_sprite_ext(spr, floor(image_index), 0, 120, 2, -2, 0, c_white, 1);
-// reset the drawing target to the screen
-surface_reset_target();
-
-// increase the shift amount; this will cycle the colours
-shift += 0.01;
-
-
-
-

--- a/SonicTT/objects/objTimeTravel/Step_2.gml
+++ b/SonicTT/objects/objTimeTravel/Step_2.gml
@@ -1,0 +1,8 @@
+/// @description Animate
+event_inherited();
+shift += cycle_speed; // this will cycle the colors
+switch (state)
+{
+case "exiting": image_index += frame_speed; break;
+case "entering": image_index -= frame_speed; break;
+}

--- a/SonicTT/objects/objTimeTravel/objTimeTravel.yy
+++ b/SonicTT/objects/objTimeTravel/objTimeTravel.yy
@@ -33,6 +33,26 @@
             "enumb": 0,
             "eventtype": 8,
             "m_owner": "d59841a7-99d2-4781-bf19-d4594a175f93"
+        },
+        {
+            "id": "f1f02018-22b5-458f-b102-b01b3bcdee4c",
+            "modelName": "GMEvent",
+            "mvc": "1.0",
+            "IsDnD": false,
+            "collisionObjectId": "00000000-0000-0000-0000-000000000000",
+            "enumb": 72,
+            "eventtype": 8,
+            "m_owner": "d59841a7-99d2-4781-bf19-d4594a175f93"
+        },
+        {
+            "id": "4baadde7-ce0a-4cf4-9686-7946815e606d",
+            "modelName": "GMEvent",
+            "mvc": "1.0",
+            "IsDnD": false,
+            "collisionObjectId": "00000000-0000-0000-0000-000000000000",
+            "enumb": 2,
+            "eventtype": 3,
+            "m_owner": "d59841a7-99d2-4781-bf19-d4594a175f93"
         }
     ],
     "maskSpriteId": "00000000-0000-0000-0000-000000000000",
@@ -55,6 +75,6 @@
     "physicsStartAwake": true,
     "properties": null,
     "solid": false,
-    "spriteId": "00000000-0000-0000-0000-000000000000",
+    "spriteId": "f5800bd9-2b47-4f69-8a29-e29977d34eca",
     "visible": true
 }

--- a/SonicTT/objects/objTimeTravelVortex/Create_0.gml
+++ b/SonicTT/objects/objTimeTravelVortex/Create_0.gml
@@ -1,49 +1,39 @@
-/// @description  Setup Shader
+/// @description Initialize
+event_inherited();
+image_speed = 0;
+image_xscale = 0;
+image_yscale = 0;
+
 /*
 TIME TRAVEL EFFECT
-This effect is achieved by drawing an animation (in this case, a scaled sprite) to a surface.
-This results in a white on transparent image on the surface. When the surface is drawn with the TimeTravelShader applied,
-the white pixels will be replaced with a texture that makes it look like the SCD time travel effect.
+This effect is achieved by drawing an animation (in this case, a scaled sprite)
+to a surface. This results in a white on transparent image on the surface. When
+the surface is drawn with the TimeTravelShader applied, the white pixels will be
+replaced with a texture that makes it look like the SCD time travel effect.
 */
 
-// send some information to the shader; the shader has to be set for this to work
-// (I don't know if this can be screwed up by using other shaders; if so, this info might have to be sent in the draw event...)
-shader_set(TimeTravelShader);
-// send: the scaling of the sparkly SCD texture so it will repeat enough times to not be stretched
-shader_set_uniform_f(shader_get_uniform(TimeTravelShader, "scl"), 426 / background_get_width(tt_texture), 240 / background_get_height(tt_texture));
-// send: the texture index of the sparkly SCD texture
-texture_set_stage(shader_get_sampler_index(TimeTravelShader, "mask"), background_get_texture(tt_texture));
-// send: the texture index of the the gradient used to cycle the colours
-texture_set_stage(shader_get_sampler_index(TimeTravelShader, "grad"), background_get_texture(tt_gradient));
-shader_reset();
+shader = TimeTravelShader;
+param_scl = shader_get_uniform(shader, "scl");					
+param_mask = shader_get_sampler_index(shader, "mask");			
+param_grad = shader_get_sampler_index(shader, "grad");			
+param_shift = shader_get_uniform(shader, "shift");	
 
-// create a surface the size of the screen to draw the effect on
-tt_surface = surface_create(426, 240);
+screen_width = 426;
+screen_height = 240;
+surface = surface_create(screen_width, screen_height);
+xscale = screen_width / background_get_width(tt_texture);		// the scaling of the sparkly SCD texture so it will repeat enough times to not be stretched
+yscale = screen_height / background_get_height(tt_texture);
+tx_mask = background_get_texture(tt_texture);					// the texture index of the sparkly SCD texture
+tx_grad = background_get_texture(tt_gradient);					// the texture index of the the gradient used to cycle the colours
 
-// I've included two types of "zipper animation" - see step event
-type = false;
-// the image index of the animated sprite that will be drawn to the texture
-image_index = 0;
-image_speed = 0;
-
-// the amount to shift the gradient to cycle the colours; starts at 0
-// it's also used to slide the texture horizontally to give it some motion, but you could use a 2nd value
-// if the speeds need to be tweaked
+/*
+The amount to shift the gradient to cycle the colours. It's also used to slide
+the texture horizontally to give it some motion, but you could use a 2nd value
+if the speeds need to be tweaked
+*/
 shift = 0;
+cycle_speed = 0.01;
 
-// the parameter handle to be used to send the shift amount to the shader later in the draw event
-param_shift = shader_get_uniform(TimeTravelShader, "shift");
-
-image_xscale=0;
-image_yscale=0;
-spr=sprite_index;
-xoffset=0;
-truex=x;
-truey=y;
-
-audio_play_sound(sndMetalAttack,10,false);
-
-
-
-/* */
-/*  */
+// vortex properties
+growth_speed = 0.0208;
+audio_play_sound(sndMetalAttack, 10, false);

--- a/SonicTT/objects/objTimeTravelVortex/Draw_0.gml
+++ b/SonicTT/objects/objTimeTravelVortex/Draw_0.gml
@@ -1,17 +1,13 @@
-// draw a dummy background for the effect to cover
-//draw_background_ext(zonebkg, 0, 0, 2, 2, 0, c_white, 1);
-// turn on the time travel effect shader
-// refresh surface
-//surface_set_target(tt_surface);
-shader_set(TimeTravelShader);
-// send the shift amount (for colour cycling) to the shader
-shader_set_uniform_f(param_shift, shift);
-// draw the surface with the zipper animation on it
-draw_surface_ext(tt_surface, x, y, image_xscale, image_yscale, 0, c_white, 1);
-// turn off the shader
-shader_reset();
-
-// draw the surface again below, without the shader
-// so you can see the untextured animation
-draw_surface(tt_surface, 0,512);
-
+/// @description Shade
+if (image_xscale != 0 and image_yscale != 0)
+{
+	shader_set(shader);
+	shader_set_uniform_f(param_scl, xscale, yscale);
+	texture_set_stage(param_mask, tx_mask);
+	texture_set_stage(param_grad, tx_grad);
+	shader_set_uniform_f(param_shift, shift);
+	draw_surface_ext(
+		surface, x, y, image_xscale, image_yscale, image_angle, image_blend, image_alpha
+	);
+	shader_reset();
+}

--- a/SonicTT/objects/objTimeTravelVortex/Draw_72.gml
+++ b/SonicTT/objects/objTimeTravelVortex/Draw_72.gml
@@ -1,0 +1,14 @@
+/// @description Draw Vortex
+if (image_xscale != 0 and image_yscale != 0)
+{
+	if (not surface_exists(surface))
+	{
+		surface = surface_create(screen_width, screen_height);
+	}
+	surface_set_target(surface);
+	draw_clear_alpha(0, 0)
+	draw_sprite_ext(
+		sprite_index, image_index, 0, 0, 1, 1, 0, c_white, 1
+	);
+	surface_reset_target();
+}

--- a/SonicTT/objects/objTimeTravelVortex/Step_0.gml
+++ b/SonicTT/objects/objTimeTravelVortex/Step_0.gml
@@ -1,30 +1,10 @@
-/// @description  Render Background Elements
-
-draw_sprite(sprTitleFog,0,304,1960);
-
-// set the drawing target to the surface
-if not surface_exists(tt_surface) tt_surface = surface_create(426, 240);
-surface_set_target(tt_surface);
-// clear the surface
-draw_clear_alpha(0, 0);
-// draw the sprite mirrored on the y axis to create the zipper shape
-//draw_sprite_ext(spr, floor(image_index), xoffset, 0, 1, 1, 0, c_white, 1);
-draw_sprite_ext(spr, floor(image_index), 0, 1, 1, 1, 0, c_white, 1);
-// reset the drawing target to the screen
-surface_reset_target();
-
-// increase the shift amount; this will cycle the colours
-shift += 0.01;
-
-if image_xscale < 1 {
-    image_xscale+=0.0208;
-    image_yscale+=0.0208;
-   truex-=2.5;
-   // truey-=5;
+/// @description Stretch
+if (image_xscale < 1)
+{
+	image_xscale += growth_speed;
+	x -= 2.5;
 }
-
-y=truey;
-x=truex;
-
-
-
+if (image_yscale < 1)
+{
+	image_yscale += growth_speed;
+}

--- a/SonicTT/objects/objTimeTravelVortex/Step_2.gml
+++ b/SonicTT/objects/objTimeTravelVortex/Step_2.gml
@@ -1,0 +1,2 @@
+/// @description Animate
+shift += cycle_speed; // this will cycle the colors

--- a/SonicTT/objects/objTimeTravelVortex/objTimeTravelVortex.yy
+++ b/SonicTT/objects/objTimeTravelVortex/objTimeTravelVortex.yy
@@ -33,6 +33,26 @@
             "enumb": 0,
             "eventtype": 8,
             "m_owner": "4548e955-a128-4c08-9985-587b0a8da2dd"
+        },
+        {
+            "id": "2d10daf7-9708-4568-af4e-0ef2bad34aa4",
+            "modelName": "GMEvent",
+            "mvc": "1.0",
+            "IsDnD": false,
+            "collisionObjectId": "00000000-0000-0000-0000-000000000000",
+            "enumb": 72,
+            "eventtype": 8,
+            "m_owner": "4548e955-a128-4c08-9985-587b0a8da2dd"
+        },
+        {
+            "id": "6044c663-db89-463e-92c3-9b9201fb59d3",
+            "modelName": "GMEvent",
+            "mvc": "1.0",
+            "IsDnD": false,
+            "collisionObjectId": "00000000-0000-0000-0000-000000000000",
+            "enumb": 2,
+            "eventtype": 3,
+            "m_owner": "4548e955-a128-4c08-9985-587b0a8da2dd"
         }
     ],
     "maskSpriteId": "00000000-0000-0000-0000-000000000000",


### PR DESCRIPTION
These commits fix the most recent collection of issues discovered while playing the game:

- Fixed the time travel warp shader used when 'time traveling' and also when Metal Sonic enters the cut-scene that plays after clearing Attraction Attack Zone Act 1 (Past.) Closes #15, closes #18

- Fixed the player getting stuck on flippers in Attraction Attack Zone when the game is compiled to YoYo Compiler (YYC) output. Closes #17